### PR TITLE
org-timeline: add magic cookie

### DIFF
--- a/org-timeline.el
+++ b/org-timeline.el
@@ -240,6 +240,7 @@ Return new copy of STRING."
               (setq current-line 1)))
           (buffer-string))))))
 
+;;;###autoload
 (defun org-timeline-insert-timeline ()
   "Insert graphical timeline into agenda buffer."
   (unless (buffer-narrowed-p)


### PR DESCRIPTION
This change makes it easier for the user to just add the hook without manually requiring the package (friendly for `use-package` and others).